### PR TITLE
feat: add generic next middleware

### DIFF
--- a/.changeset/brave-steaks-fly.md
+++ b/.changeset/brave-steaks-fly.md
@@ -1,0 +1,5 @@
+---
+"@cipherstash/nextjs": minor
+---
+
+Implemented a generic Next.js jseql middleware.

--- a/packages/nextjs/src/clerk/index.ts
+++ b/packages/nextjs/src/clerk/index.ts
@@ -1,7 +1,8 @@
 import type { ClerkMiddlewareAuth } from '@clerk/nextjs/server'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { CS_COOKIE_NAME, type CtsToken } from '../index'
+import { CS_COOKIE_NAME, resetCtsToken } from '../index'
+import { setCtsToken } from '../cts'
 import { logger } from '../../../utils/logger'
 
 export const jseqlClerkMiddleware = async (
@@ -22,55 +23,7 @@ export const jseqlClerkMiddleware = async (
       return NextResponse.next()
     }
 
-    const workspaceId = process.env.CS_WORKSPACE_ID
-
-    if (!workspaceId) {
-      logger.error(
-        'The "CS_WORKSPACE_ID" environment variable is not set, and is required by jseqlClerkMiddleware. No CipherStash session will be set.',
-      )
-
-      return NextResponse.next()
-    }
-
-    const ctsEndoint =
-      process.env.CS_CTS_ENDPOINT ||
-      'https://ap-southeast-2.aws.auth.viturhosted.net'
-
-    const ctsResponse = await fetch(`${ctsEndoint}/api/authorize`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        workspaceId,
-        oidcToken,
-      }),
-    })
-
-    if (!ctsResponse.ok) {
-      logger.debug(`Failed to fetch CTS token: ${ctsResponse.statusText}`)
-
-      logger.error(
-        'There was an issue communicating with the CipherStash CTS API, the CipherStash session was not set. If the issue persists, please contact support.',
-      )
-
-      return NextResponse.next()
-    }
-
-    const cts_token = (await ctsResponse.json()) as CtsToken
-
-    // Setting cookies on the request and response using the `ResponseCookies` API
-    const response = NextResponse.next()
-    response.cookies.set({
-      name: CS_COOKIE_NAME,
-      value: JSON.stringify(cts_token),
-      expires: new Date(cts_token.expiry * 1000),
-      sameSite: 'lax',
-      path: '/',
-    })
-
-    response.cookies.get(CS_COOKIE_NAME)
-    return response
+    return await setCtsToken(oidcToken)
   }
 
   if (!userId && ctsSession) {
@@ -78,9 +31,7 @@ export const jseqlClerkMiddleware = async (
       'No Clerk token found in the request, so the CipherStash session was reset.',
     )
 
-    const response = NextResponse.next()
-    response.cookies.delete(CS_COOKIE_NAME)
-    return response
+    return resetCtsToken()
   }
 
   logger.debug(

--- a/packages/nextjs/src/cts/index.ts
+++ b/packages/nextjs/src/cts/index.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server'
+import { logger } from '../../../utils/logger'
+import { CS_COOKIE_NAME, type CtsToken } from '../index'
+
+export const setCtsToken = async (oidcToken: string) => {
+  const workspaceId = process.env.CS_WORKSPACE_ID
+
+  if (!workspaceId) {
+    logger.error(
+      'The "CS_WORKSPACE_ID" environment variable is not set, and is required by jseqlClerkMiddleware. No CipherStash session will be set.',
+    )
+
+    return NextResponse.next()
+  }
+
+  const ctsEndoint =
+    process.env.CS_CTS_ENDPOINT ||
+    'https://ap-southeast-2.aws.auth.viturhosted.net'
+
+  const ctsResponse = await fetch(`${ctsEndoint}/api/authorize`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      workspaceId,
+      oidcToken,
+    }),
+  })
+
+  if (!ctsResponse.ok) {
+    logger.debug(`Failed to fetch CTS token: ${ctsResponse.statusText}`)
+
+    logger.error(
+      'There was an issue communicating with the CipherStash CTS API, the CipherStash session was not set. If the issue persists, please contact support.',
+    )
+
+    return NextResponse.next()
+  }
+
+  const cts_token = (await ctsResponse.json()) as CtsToken
+
+  // Setting cookies on the request and response using the `ResponseCookies` API
+  const response = NextResponse.next()
+  response.cookies.set({
+    name: CS_COOKIE_NAME,
+    value: JSON.stringify(cts_token),
+    expires: new Date(cts_token.expiry * 1000),
+    sameSite: 'lax',
+    path: '/',
+  })
+
+  response.cookies.get(CS_COOKIE_NAME)
+  return response
+}


### PR DESCRIPTION
This adds a generic next.js middleware function. The `jseqlMiddleware` function will take the JWT token of the user session, and also exposes a method for clearing the CipherStash CTS cookie in case you are using custom middleware logic. 