### PR TITLE
fix: unintented encryptions/decryptions with a lock context

### DIFF
--- a/.changeset/fresh-windows-call.md
+++ b/.changeset/fresh-windows-call.md
@@ -1,0 +1,8 @@
+---
+"@cipherstash/jseql": major
+---
+
+Enforced lock context to be called as a proto function rather than an optional argument for crypto functions.
+There was a bug that caused the lock context to be interpreted as undefined when the users intention was to use it causing the encryption/decryption to fail.
+This is a breaking change for users who were using the lock context as an optional argument.
+To use the lock context, call the `withLockContext` method on the encrypt, decrypt, and bulk encrypt/decrypt functions, passing the lock context as a parameter rather than as an optional argument.

--- a/.changeset/strange-bees-hope.md
+++ b/.changeset/strange-bees-hope.md
@@ -1,0 +1,5 @@
+---
+"@cipherstash/nextjs": major
+---
+
+Implemented better error handling for fetching CTS tokens and accessing them in the Next.js application.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ The `decrypt` function returns a string with the plaintext data.
 
 ### Lock context
 
+> [!CAUTION]
+> If you use a lock context to encrypt data, you must also use the same lock context to decrypt the data.
+> Otherwise, you will receive a `400` error from ZeroKMS indicating that the request was unable to generate a data key, and you will be unable to decrypt the data.
+
 `jseql` supports lock contexts to ensure that only the intended users can access sensitive data.
 To use a lock context, initialize a `LockContext` object with the identity claims.
 
@@ -162,11 +166,11 @@ const lc = new LockContext()
 ```
 
 > [!NOTE]
-> At the time of this writing, the default LockContext context is set to use the `sub` Identity Claim.
+> When initializing a `LockContext` the default context is set to use the `sub` Identity Claim.
 
 **Custom context**
 
-If you want to use a custom context, you can pass it to the `LockContext` constructor.
+If you want to override the default context, you can pass a custom context to the `LockContext` constructor.
 
 ```typescript
 import { LockContext } from '@cipherstash/jseql/identify'
@@ -174,20 +178,22 @@ import { LockContext } from '@cipherstash/jseql/identify'
 // eqlClient from the previous steps
 const lc = new LockContext({
   context: {
-    identityClaim: ['sub'],
+    identityClaim: ['sub'], // this is the default context
   },
 })
 ```
 
 **Context and identity claim options**
 
-The context must be an object with an `identityClaim` property.
+The context object contains an `identityClaim` property.
 The `identityClaim` property must be an array of strings that correspond to the Identity Claim(s) you want to lock the encryption operation to.
 
-| Identity Claim | Description | Default |
-| -------------- | ----------- | ------- |
-| `sub`          | The user's subject identifier. | yes |
-| `scopes`       | The user's scopes set by your IDP policy. | no |
+Currently supported Identity Claims are:
+
+| Identity Claim | Description |
+| -------------- | ----------- |
+| `sub`          | The user's subject identifier. |
+| `scopes`       | The user's scopes set by your IDP policy. |
 
 #### Identifying the user
 

--- a/biome.json
+++ b/biome.json
@@ -14,5 +14,12 @@
       "quoteStyle": "single",
       "semicolons": "asNeeded"
     }
+  },
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noThenProperty": "off"
+      }
+    }
   }
 }

--- a/packages/jseql/__tests__/jseql.test.ts
+++ b/packages/jseql/__tests__/jseql.test.ts
@@ -111,7 +111,7 @@ describe('getPlaintext', () => {
   })
 })
 
-describe('jseql-ffi', () => {
+describe('encryption and decryption', () => {
   it('should have all required environment variables defined', () => {
     expect(process.env.CS_CLIENT_ID).toBeDefined()
     expect(process.env.CS_CLIENT_KEY).toBeDefined()
@@ -143,48 +143,6 @@ describe('jseql-ffi', () => {
     const plaintext = await eqlClient.decrypt(ciphertext)
 
     expect(plaintext).toEqual(null)
-  }, 30000)
-
-  it('should encrypt and decrypt a payload with lock context', async () => {
-    const eqlClient = await eql()
-
-    const lc = new LockContext()
-
-    // TODO: implement lockContext when CTS v2 is deployed
-    // const lockContext = await lc.identify('users_1_jwt')
-
-    const ciphertext = await eqlClient.encrypt('plaintext', {
-      column: 'column_name',
-      table: 'users',
-    })
-
-    const plaintext = await eqlClient.decrypt(ciphertext)
-
-    expect(plaintext).toEqual('plaintext')
-  }, 30000)
-
-  it('should encrypt with context and be unable to decrypt without correct context', async () => {
-    const eqlClient = await eql()
-
-    const lc = new LockContext()
-
-    // const lockContext = await lc.identify('users_1_jwt')
-
-    const ciphertext = await eqlClient.encrypt('plaintext', {
-      column: 'column_name',
-      table: 'users',
-    })
-
-    const incorrectLc = new LockContext()
-
-    // const badLockContext = await incorrectLc.identify('users_2_jwt')
-
-    try {
-      await eqlClient.decrypt(ciphertext)
-    } catch (error) {
-      const e = error as Error
-      expect(e.message.startsWith('Failed to retrieve key')).toEqual(true)
-    }
   }, 30000)
 })
 
@@ -238,3 +196,93 @@ describe('bulk encryption', () => {
     expect(plaintexts).toEqual(null)
   }, 30000)
 })
+
+// ------------------------
+// TODO get bulk Encryption/Decryption working in CI.
+// These tests pass locally, given you provide a valid JWT.
+// To manually test locally, uncomment the following lines and provide a valid JWT in the userJwt variable.
+// ------------------------
+// const userJwt = ''
+// describe('encryption and decryption with lock context', () => {
+//   it('should encrypt and decrypt a payload with lock context', async () => {
+//     const eqlClient = await eql()
+
+//     const lc = new LockContext()
+//     const lockContext = await lc.identify(userJwt)
+
+//     const ciphertext = await eqlClient
+//       .encrypt('plaintext', {
+//         column: 'column_name',
+//         table: 'users',
+//       })
+//       .withLockContext(lockContext)
+
+//     const plaintext = await eqlClient
+//       .decrypt(ciphertext)
+//       .withLockContext(lockContext)
+
+//     expect(plaintext).toEqual('plaintext')
+//   }, 30000)
+
+//   it('should encrypt with context and be unable to decrypt without context', async () => {
+//     const eqlClient = await eql()
+
+//     const lc = new LockContext()
+//     const lockContext = await lc.identify(userJwt)
+
+//     const ciphertext = await eqlClient
+//       .encrypt('plaintext', {
+//         column: 'column_name',
+//         table: 'users',
+//       })
+//       .withLockContext(lockContext)
+
+//     try {
+//       await eqlClient.decrypt(ciphertext)
+//     } catch (error) {
+//       const e = error as Error
+//       expect(e.message.startsWith('Failed to retrieve key')).toEqual(true)
+//     }
+//   }, 30000)
+
+//   it('should bulk encrypt and decrypt a payload with lock context', async () => {
+//     const eqlClient = await eql()
+
+//     const lc = new LockContext()
+//     const lockContext = await lc.identify(userJwt)
+
+//     const ciphertexts = await eqlClient
+//       .bulkEncrypt(
+//         [
+//           {
+//             plaintext: 'test',
+//             id: '1',
+//           },
+//           {
+//             plaintext: 'test2',
+//             id: '2',
+//           },
+//         ],
+//         {
+//           table: 'users',
+//           column: 'column_name',
+//         },
+//       )
+//       .withLockContext(lockContext)
+
+//     const plaintexts = await eqlClient
+//       .bulkDecrypt(ciphertexts)
+//       .withLockContext(lockContext)
+
+//     expect(plaintexts).toEqual([
+//       {
+//         plaintext: 'test',
+//         id: '1',
+//       },
+//       {
+//         plaintext: 'test2',
+//         id: '2',
+//       },
+//     ])
+//   }, 30000)
+// })

--- a/packages/jseql/src/ffi/index.ts
+++ b/packages/jseql/src/ffi/index.ts
@@ -1,256 +1,29 @@
 import {
   newClient,
-  decrypt,
-  encrypt,
-  encryptBulk,
-  decryptBulk,
+  encrypt as ffiEncrypt,
+  decrypt as ffiDecrypt,
+  encryptBulk as ffiEncryptBulk,
+  decryptBulk as ffiDecryptBulk,
 } from '@cipherstash/jseql-ffi'
 import { logger } from '../../../utils/logger'
-import type { LockContext } from '../identify'
 import { checkEnvironmentVariables } from './env-check'
 import {
-  normalizeBulkDecryptPayloads,
   normalizeBulkEncryptPayloads,
+  normalizeBulkDecryptPayloads,
 } from './payload-helpers'
+import type { LockContext } from '../identify'
 
-type Client = Awaited<ReturnType<typeof newClient>> | undefined
-
-const noClientError = () =>
-  new Error(
-    'The EQL client has not been initialized. Please call the init() method before using the client.',
-  )
-
-export class EqlClient {
-  private client: Client
-  private workspaceId
-
-  constructor() {
-    checkEnvironmentVariables()
-
-    logger.info(
-      'Successfully initialized the EQL client with your defined environment variables.',
-    )
-
-    this.workspaceId = process.env.CS_WORKSPACE_ID
-  }
-
-  async init(): Promise<EqlClient> {
-    const client = await newClient()
-    this.client = client
-    return this
-  }
-
-  async encrypt(
-    plaintext: EncryptPayload,
-    { column, table, lockContext }: EncryptOptions,
-  ): Promise<EncryptedPayload> {
-    if (!this.client) {
-      throw noClientError()
-    }
-
-    if (plaintext === null) {
-      return null
-    }
-
-    if (lockContext) {
-      const { ctsToken, context } = lockContext.getLockContext()
-
-      logger.debug('Encrypting data with lock context', {
-        context,
-        column,
-        table,
-      })
-
-      return await encrypt(
-        this.client,
-        plaintext,
-        column,
-        {
-          identityClaim: context.identityClaim,
-        },
-        ctsToken,
-      ).then((val: string) => {
-        return { c: val }
-      })
-    }
-
-    logger.debug('Encrypting data without a lock context', {
-      column,
-      table,
-    })
-
-    return await encrypt(this.client, plaintext, column).then((val: string) => {
-      return { c: val }
-    })
-  }
-
-  // make decrypt options optional
-  async decrypt(
-    encryptedPayload: EncryptedPayload,
-    { lockContext }: DecryptOptions = {},
-  ): Promise<string | null> {
-    if (!this.client) {
-      throw noClientError()
-    }
-
-    if (encryptedPayload === null) {
-      return null
-    }
-
-    try {
-      if (lockContext) {
-        const { ctsToken, context } = lockContext.getLockContext()
-
-        logger.debug('Decrypting data with lock context', {
-          context,
-        })
-
-        return await decrypt(
-          this.client,
-          encryptedPayload.c,
-          {
-            identityClaim: context.identityClaim,
-          },
-          ctsToken,
-        )
-      }
-
-      logger.debug('Decrypting data without a lock context')
-      return await decrypt(this.client, encryptedPayload.c)
-    } catch (error) {
-      logger.debug((error as Error).message)
-      return encryptedPayload.c
-    }
-  }
-
-  async bulkEncrypt(
-    plaintexts: BulkEncryptPayload,
-    { column, table, lockContext }: EncryptOptions,
-  ): Promise<BulkEncryptedData> {
-    if (!this.client) {
-      throw noClientError()
-    }
-
-    if (plaintexts.length === 0 || plaintexts === null) {
-      return null
-    }
-
-    const encryptPayloads = normalizeBulkEncryptPayloads(
-      plaintexts,
-      column,
-      lockContext,
-    )
-
-    logger.debug('Bulk encrypting data...', {
-      column,
-      table,
-    })
-
-    let encryptedData: string[]
-
-    if (lockContext) {
-      const { ctsToken, context } = lockContext.getLockContext()
-
-      logger.debug('Bulk encrypting data with lock context', {
-        context,
-        column,
-        table,
-      })
-
-      encryptedData = await encryptBulk(this.client, encryptPayloads, ctsToken)
-    } else {
-      logger.debug('Bulk encrypting data without a lock context', {
-        column,
-        table,
-      })
-
-      encryptedData = await encryptBulk(this.client, encryptPayloads)
-    }
-
-    const response = encryptedData?.map((encryptedData, index) => {
-      return {
-        c: encryptedData,
-        id: plaintexts[index].id,
-      }
-    })
-
-    return response
-  }
-
-  async bulkDecrypt(
-    encryptedPayloads: BulkEncryptedData,
-    { lockContext }: DecryptOptions = {},
-  ): Promise<BulkDecryptedData> {
-    if (!this.client) {
-      throw noClientError()
-    }
-
-    const decryptPayloads = normalizeBulkDecryptPayloads(
-      encryptedPayloads,
-      lockContext,
-    )
-
-    if (!decryptPayloads) {
-      return null
-    }
-
-    let decryptedData: string[]
-
-    if (lockContext) {
-      const { ctsToken, context } = lockContext.getLockContext()
-
-      logger.debug('Decrypting data with lock context', {
-        context,
-      })
-
-      decryptedData = await decryptBulk(this.client, decryptPayloads, ctsToken)
-    } else {
-      logger.debug('Decrypting data without a lock context')
-      decryptedData = await decryptBulk(this.client, decryptPayloads)
-    }
-
-    const response = decryptedData?.map((decryptedData, index) => {
-      if (!encryptedPayloads) {
-        return null
-      }
-
-      return {
-        plaintext: decryptedData,
-        id: encryptedPayloads[index].id,
-      }
-    })
-
-    return response
-  }
-
-  clientInfo() {
-    return {
-      workspaceId: this.workspaceId,
-    }
-  }
-}
-
+// ------------------------
+// Type Definitions
+// ------------------------
 export type EncryptPayload = string | null
+
+export type EncryptedPayload = { c: string } | null
 
 export type BulkEncryptPayload = {
   plaintext: string
   id: string
 }[]
-
-export type EncryptOptions = {
-  column: string
-  table: string
-  lockContext?: LockContext
-}
-
-// make decrypt options optional
-export type DecryptOptions = {
-  lockContext?: LockContext
-}
-
-export type EncryptedPayload = {
-  c: string
-} | null
 
 export type BulkEncryptedData =
   | {
@@ -265,3 +38,380 @@ export type BulkDecryptedData =
       id: string
     } | null)[]
   | null
+
+export type EncryptOptions = {
+  column: string
+  table: string
+}
+
+type Client = Awaited<ReturnType<typeof newClient>> | undefined
+
+const noClientError = () =>
+  new Error(
+    'The EQL client has not been initialized. Please call init() before using the client.',
+  )
+
+class EncryptOperation implements PromiseLike<EncryptedPayload> {
+  private client: Client
+  private plaintext: EncryptPayload
+  private column: string
+  private table: string
+  private lockContext?: LockContext
+
+  constructor(client: Client, plaintext: EncryptPayload, opts: EncryptOptions) {
+    this.client = client
+    this.plaintext = plaintext
+    this.column = opts.column
+    this.table = opts.table
+  }
+
+  /** Optional lock context token. */
+  public withLockContext(lockContext: LockContext): this {
+    this.lockContext = lockContext
+    return this
+  }
+
+  /** Implement the PromiseLike interface so `await` works. */
+  public then<TResult1 = EncryptedPayload, TResult2 = never>(
+    onfulfilled?:
+      | ((value: EncryptedPayload) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    // biome-ignore lint/suspicious/noExplicitAny: Rejections require an any type
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  /** Actual encryption logic, deferred until `then()` is called. */
+  private async execute(): Promise<EncryptedPayload> {
+    if (!this.client) {
+      throw noClientError()
+    }
+    if (this.plaintext === null) {
+      return null
+    }
+
+    // If a lock token was provided, we'll pass it to the FFI.
+    if (this.lockContext) {
+      logger.debug('Encrypting data WITH a lock context', {
+        column: this.column,
+        table: this.table,
+      })
+
+      const val = await ffiEncrypt(
+        this.client,
+        this.plaintext,
+        this.column,
+        this.lockContext.getLockContext().context,
+        this.lockContext.getLockContext().ctsToken,
+      )
+      return { c: val }
+    }
+
+    logger.debug('Encrypting data WITHOUT a lock context', {
+      column: this.column,
+      table: this.table,
+    })
+
+    const val = await ffiEncrypt(this.client, this.plaintext, this.column)
+    return { c: val }
+  }
+}
+
+class DecryptOperation implements PromiseLike<string | null> {
+  private client: Client
+  private encryptedPayload: EncryptedPayload
+  private lockContext?: LockContext
+
+  constructor(client: Client, encryptedPayload: EncryptedPayload) {
+    this.client = client
+    this.encryptedPayload = encryptedPayload
+  }
+
+  public withLockContext(lockContext: LockContext): this {
+    this.lockContext = lockContext
+    return this
+  }
+
+  public then<TResult1 = string | null, TResult2 = never>(
+    onfulfilled?:
+      | ((value: string | null) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    // biome-ignore lint/suspicious/noExplicitAny: Rejections require an any type
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  private async execute(): Promise<string | null> {
+    if (!this.client) {
+      throw noClientError()
+    }
+
+    if (this.encryptedPayload === null) {
+      return null
+    }
+
+    try {
+      if (this.lockContext) {
+        logger.debug('Decrypting data WITH a lock context')
+
+        return await ffiDecrypt(
+          this.client,
+          this.encryptedPayload.c,
+          this.lockContext.getLockContext().context,
+          this.lockContext.getLockContext().ctsToken,
+        )
+      }
+
+      logger.debug('Decrypting data WITHOUT a lock context')
+      return await ffiDecrypt(this.client, this.encryptedPayload.c)
+    } catch (error) {
+      logger.debug((error as Error).message)
+      // Return original ciphertext if we fail to maintain application integrity
+      return this.encryptedPayload.c
+    }
+  }
+}
+
+class BulkEncryptOperation implements PromiseLike<BulkEncryptedData> {
+  private client: Client
+  private plaintexts: BulkEncryptPayload
+  private column: string
+  private table: string
+  private lockContext?: LockContext
+
+  constructor(
+    client: Client,
+    plaintexts: BulkEncryptPayload,
+    opts: EncryptOptions,
+  ) {
+    this.client = client
+    this.plaintexts = plaintexts
+    this.column = opts.column
+    this.table = opts.table
+  }
+
+  public withLockContext(lockContext: LockContext): this {
+    this.lockContext = lockContext
+    return this
+  }
+
+  public then<TResult1 = BulkEncryptedData, TResult2 = never>(
+    onfulfilled?:
+      | ((value: BulkEncryptedData) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    // biome-ignore lint/suspicious/noExplicitAny: Rejections require an any type
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  private async execute(): Promise<BulkEncryptedData> {
+    if (!this.client) {
+      throw noClientError()
+    }
+
+    if (!this.plaintexts || this.plaintexts.length === 0) {
+      return null
+    }
+
+    const encryptPayloads = normalizeBulkEncryptPayloads(
+      this.plaintexts,
+      this.column,
+      this.lockContext || undefined,
+    )
+
+    if (this.lockContext) {
+      logger.debug('Bulk encrypting data WITH a lock context', {
+        column: this.column,
+        table: this.table,
+      })
+
+      const encryptedData = await ffiEncryptBulk(
+        this.client,
+        encryptPayloads,
+        this.lockContext.getLockContext().ctsToken,
+      )
+
+      return encryptedData.map((enc, index) => ({
+        c: enc,
+        id: this.plaintexts[index].id,
+      }))
+    }
+
+    logger.debug('Bulk encrypting data WITHOUT a lock context', {
+      column: this.column,
+      table: this.table,
+    })
+
+    const encryptedData = await ffiEncryptBulk(this.client, encryptPayloads)
+    return encryptedData.map((enc, index) => ({
+      c: enc,
+      id: this.plaintexts[index].id,
+    }))
+  }
+}
+
+class BulkDecryptOperation implements PromiseLike<BulkDecryptedData> {
+  private client: Client
+  private encryptedPayloads: BulkEncryptedData
+  private lockContext?: LockContext
+
+  constructor(client: Client, encryptedPayloads: BulkEncryptedData) {
+    this.client = client
+    this.encryptedPayloads = encryptedPayloads
+  }
+
+  public withLockContext(lockContext: LockContext): this {
+    this.lockContext = lockContext
+    return this
+  }
+
+  public then<TResult1 = BulkDecryptedData, TResult2 = never>(
+    onfulfilled?:
+      | ((value: BulkDecryptedData) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    // biome-ignore lint/suspicious/noExplicitAny: Rejections require an any type
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  private async execute(): Promise<BulkDecryptedData> {
+    if (!this.client) {
+      throw noClientError()
+    }
+
+    if (!this.encryptedPayloads) {
+      return null
+    }
+
+    const decryptPayloads = normalizeBulkDecryptPayloads(
+      this.encryptedPayloads,
+      this.lockContext || undefined,
+    )
+
+    if (!decryptPayloads) {
+      return null
+    }
+
+    if (this.lockContext) {
+      logger.debug('Bulk decrypting data WITH a lock context')
+
+      const decryptedData = await ffiDecryptBulk(
+        this.client,
+        decryptPayloads,
+        this.lockContext.getLockContext().ctsToken,
+      )
+
+      return decryptedData.map((dec, index) => {
+        if (!this.encryptedPayloads) return null
+        return {
+          plaintext: dec,
+          id: this.encryptedPayloads[index].id,
+        }
+      })
+    }
+
+    logger.debug('Bulk decrypting data WITHOUT a lock context')
+
+    const decryptedData = await ffiDecryptBulk(this.client, decryptPayloads)
+    return decryptedData.map((dec, index) => {
+      if (!this.encryptedPayloads) return null
+      return {
+        plaintext: dec,
+        id: this.encryptedPayloads[index].id,
+      }
+    })
+  }
+}
+
+export class EqlClient {
+  private client: Client
+  private workspaceId: string | undefined
+
+  constructor() {
+    checkEnvironmentVariables()
+
+    logger.info(
+      'Successfully initialized the EQL client with your defined environment variables.',
+    )
+
+    this.workspaceId = process.env.CS_WORKSPACE_ID
+  }
+
+  async init(): Promise<EqlClient> {
+    const c = await newClient()
+    this.client = c
+    return this
+  }
+
+  /**
+   * Encryption - returns a thenable object.
+   * Usage:
+   *    await eqlClient.encrypt(plaintext, { column, table })
+   *    await eqlClient.encrypt(plaintext, { column, table }).withLockContext('some-cts-token')
+   */
+  encrypt(plaintext: EncryptPayload, opts: EncryptOptions): EncryptOperation {
+    if (!this.client) {
+      throw noClientError()
+    }
+
+    return new EncryptOperation(this.client, plaintext, opts)
+  }
+
+  /**
+   * Decryption - returns a thenable object.
+   * Usage:
+   *    await eqlClient.decrypt(encryptedPayload)
+   *    await eqlClient.decrypt(encryptedPayload).withLockContext('some-cts-token')
+   */
+  decrypt(encryptedPayload: EncryptedPayload): DecryptOperation {
+    if (!this.client) {
+      throw noClientError()
+    }
+
+    return new DecryptOperation(this.client, encryptedPayload)
+  }
+
+  /**
+   * Bulk Encrypt - returns a thenable object.
+   * Usage:
+   *    await eqlClient.bulkEncrypt([{ plaintext, id }, ...], { column, table })
+   *    await eqlClient
+   *      .bulkEncrypt([{ plaintext, id }, ...], { column, table })
+   *      .withLockContext('some-cts-token')
+   */
+  bulkEncrypt(
+    plaintexts: BulkEncryptPayload,
+    opts: EncryptOptions,
+  ): BulkEncryptOperation {
+    if (!this.client) {
+      throw noClientError()
+    }
+
+    return new BulkEncryptOperation(this.client, plaintexts, opts)
+  }
+
+  /**
+   * Bulk Decrypt - returns a thenable object.
+   * Usage:
+   *    await eqlClient.bulkDecrypt(encryptedPayloads)
+   *    await eqlClient.bulkDecrypt(encryptedPayloads).withLockContext('some-cts-token')
+   */
+  bulkDecrypt(encryptedPayloads: BulkEncryptedData): BulkDecryptOperation {
+    if (!this.client) {
+      throw noClientError()
+    }
+
+    return new BulkDecryptOperation(this.client, encryptedPayloads)
+  }
+
+  /** e.g., debugging or environment info */
+  clientInfo() {
+    return {
+      workspaceId: this.workspaceId,
+    }
+  }
+}

--- a/packages/jseql/src/ffi/index.ts
+++ b/packages/jseql/src/ffi/index.ts
@@ -10,6 +10,8 @@ import { checkEnvironmentVariables } from './env-check'
 import {
   normalizeBulkEncryptPayloads,
   normalizeBulkDecryptPayloads,
+  normalizeBulkEncryptPayloadsWithLockContext,
+  normalizeBulkDecryptPayloadsWithLockContext,
 } from './payload-helpers'
 import type { LockContext } from '../identify'
 
@@ -317,7 +319,6 @@ class BulkEncryptOperation implements PromiseLike<BulkEncryptedData> {
     const encryptPayloads = normalizeBulkEncryptPayloads(
       this.plaintexts,
       this.column,
-      false,
     )
 
     logger.debug('Bulk encrypting data WITHOUT a lock context', {
@@ -379,10 +380,9 @@ class BulkEncryptOperationWithLockContext
       return null
     }
 
-    const encryptPayloads = normalizeBulkEncryptPayloads(
+    const encryptPayloads = normalizeBulkEncryptPayloadsWithLockContext(
       plaintexts,
       column,
-      true,
       this.lockContext,
     )
 
@@ -447,10 +447,7 @@ class BulkDecryptOperation implements PromiseLike<BulkDecryptedData> {
       return null
     }
 
-    const decryptPayloads = normalizeBulkDecryptPayloads(
-      this.encryptedPayloads,
-      false,
-    )
+    const decryptPayloads = normalizeBulkDecryptPayloads(this.encryptedPayloads)
 
     if (!decryptPayloads) {
       return null
@@ -511,9 +508,8 @@ class BulkDecryptOperationWithLockContext
       return null
     }
 
-    const decryptPayloads = normalizeBulkDecryptPayloads(
+    const decryptPayloads = normalizeBulkDecryptPayloadsWithLockContext(
       encryptedPayloads,
-      true,
       this.lockContext,
     )
 

--- a/packages/jseql/src/ffi/payload-helpers.ts
+++ b/packages/jseql/src/ffi/payload-helpers.ts
@@ -6,20 +6,7 @@ import type {
 import type { BulkEncryptPayload, BulkEncryptedData } from './index'
 import type { LockContext } from '../identify'
 
-const getLockContextPayload = (
-  usingLockContext: boolean,
-  lockContext?: LockContext,
-) => {
-  if (!usingLockContext) {
-    return {}
-  }
-
-  if (!lockContext) {
-    throw new Error(
-      '[jseql]: LockContext is required when using a lock context',
-    )
-  }
-
+const getLockContextPayload = (lockContext: LockContext) => {
   const context = lockContext.getLockContext()
 
   if (!context.ctsToken?.accessToken) {
@@ -35,13 +22,10 @@ const getLockContextPayload = (
 
 export const normalizeBulkDecryptPayloads = (
   encryptedPayloads: BulkEncryptedData,
-  usingLockContext: boolean,
-  lockContext?: LockContext,
 ) =>
   encryptedPayloads?.reduce((acc, encryptedPayload) => {
     const payload = {
       ciphertext: encryptedPayload.c,
-      ...getLockContextPayload(usingLockContext, lockContext),
     }
 
     acc.push(payload)
@@ -51,14 +35,41 @@ export const normalizeBulkDecryptPayloads = (
 export const normalizeBulkEncryptPayloads = (
   plaintexts: BulkEncryptPayload,
   column: string,
-  usingLockContext: boolean,
-  lockContext?: LockContext,
 ) =>
   plaintexts.reduce((acc, plaintext) => {
     const payload = {
       plaintext: plaintext.plaintext,
       column,
-      ...getLockContextPayload(usingLockContext, lockContext),
+    }
+
+    acc.push(payload)
+    return acc
+  }, [] as InternalBulkEncryptPayload[])
+
+export const normalizeBulkDecryptPayloadsWithLockContext = (
+  encryptedPayloads: BulkEncryptedData,
+  lockContext: LockContext,
+) =>
+  encryptedPayloads?.reduce((acc, encryptedPayload) => {
+    const payload = {
+      ciphertext: encryptedPayload.c,
+      ...getLockContextPayload(lockContext),
+    }
+
+    acc.push(payload)
+    return acc
+  }, [] as InternalBulkDecryptPayload[])
+
+export const normalizeBulkEncryptPayloadsWithLockContext = (
+  plaintexts: BulkEncryptPayload,
+  column: string,
+  lockContext: LockContext,
+) =>
+  plaintexts.reduce((acc, plaintext) => {
+    const payload = {
+      plaintext: plaintext.plaintext,
+      column,
+      ...getLockContextPayload(lockContext),
     }
 
     acc.push(payload)

--- a/packages/jseql/src/identify/index.ts
+++ b/packages/jseql/src/identify/index.ts
@@ -20,6 +20,20 @@ export type LockContextOptions = {
   ctsToken?: CtsToken
 }
 
+export type GetLockContextResponse =
+  | {
+      success: boolean
+      error: string
+      ctsToken?: never
+      context?: never
+    }
+  | {
+      success: boolean
+      error?: never
+      ctsToken: CtsToken
+      context: Context
+    }
+
 export class LockContext {
   private ctsToken: CtsToken | undefined
   private workspaceId: string
@@ -82,18 +96,17 @@ export class LockContext {
     return this
   }
 
-  getLockContext(): {
-    context: Context
-    ctsToken: CtsToken
-  } {
-    if (!this.ctsToken) {
-      const errorMessage =
-        'Please call identify() with a users JWT token, or pass an existing CTS token to the LockContext constructor before calling getLockContext().'
-      logger.error(errorMessage)
-      throw new Error(errorMessage)
+  getLockContext(): GetLockContextResponse {
+    if (!this.ctsToken?.accessToken && !this.ctsToken?.expiry) {
+      return {
+        success: false,
+        error:
+          'The CTS token is not set. Please call identify() with a users JWT token, or pass an existing CTS token to the LockContext constructor before calling getLockContext().',
+      }
     }
 
     return {
+      success: true,
       context: this.context,
       ctsToken: this.ctsToken,
     }


### PR DESCRIPTION
Enforced lock context to be called as a proto function rather than an optional argument for crypto functions.

There was a bug that caused the lock context to be interpreted as undefined when the users intention was to use it causing the encryption/decryption to fail.

This is a breaking change for users who were using the lock context as an optional argument, hence the major version bump.

To use the lock context, call the `withLockContext` method on the encrypt, decrypt, and bulk encrypt/decrypt functions, passing the lock context as a parameter rather than as an optional argument.

Old:

```typescript
const ciphertext = await eqlClient.encrypt('plaintext', {
  column: 'column_name',
  table: 'users',
  lockContext,
})

const plaintext = await eqlClient.decrypt(ciphertext)
```

New:

```typescript
const ciphertext = await eqlClient.encrypt('plaintext', {
  column: 'column_name',
  table: 'users',
}).withLockContext(lockContext)
```